### PR TITLE
Testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,4 @@ Description: This package provides an R wrapper for the Zendesk API
 Github: http://www.github.com/tcash21/zendeskR
 License: GPL-2
 RoxygenNote: 6.0.1
+Suggests: testthat

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(zendeskR)
+
+test_check("zendeskR")

--- a/tests/testthat/helper-api_access.R
+++ b/tests/testthat/helper-api_access.R
@@ -1,0 +1,19 @@
+check_zendesk_login <- function() {
+    if (!file.exists('testing_login.R')) {
+        skip("Please create a testing_login.R file with your 
+             credentials in the zendesk() function to run 
+             these tests")
+    }
+}
+
+not_working <- function() {
+    source('testing_login.R')
+}
+
+check_api <- function() {
+    if (not_working()) {
+        skip("API not available")
+    }
+}
+
+

--- a/tests/testthat/helper-api_access.R
+++ b/tests/testthat/helper-api_access.R
@@ -1,4 +1,6 @@
 check_zendesk_login <- function() {
+    # skip_on_cran()
+    
     if (!file.exists('testing_login.R')) {
         skip("Please create a testing_login.R file with your 
              credentials in the zendesk() function to run 
@@ -6,14 +8,22 @@ check_zendesk_login <- function() {
     }
 }
 
-not_working <- function() {
-    source('testing_login.R')
+check_api <- function(){
+    # skip_on_cran()
+    
+    check_zendesk_login()
+    # not_working()
 }
 
-check_api <- function() {
-    if (not_working()) {
-        skip("API not available")
-    }
-}
+# TODO: add something to check that zendesk api is online
+# not_working <- function() {
+#     # this may be easier affter implementing .httr
+#     source('testing_login.R')
+# if () {
+#         skip("API not available")
+#     }
+# }
 
-
+# TODO: add a function to check if user is an admin
+# Should do after adding functionality to pull specific
+# users then check status of user from .ZendeskEnv$data$username

--- a/tests/testthat/test-organizations.R
+++ b/tests/testthat/test-organizations.R
@@ -1,0 +1,8 @@
+context('Organizations')
+
+test_that('organizations downloaded', {
+    check_zendesk_login()
+    source('testing_login.R')
+    all_orgs <- getAllOrganizations()
+    expect_is(all_orgs, 'data.frame')
+})

--- a/tests/testthat/test-organizations.R
+++ b/tests/testthat/test-organizations.R
@@ -1,7 +1,8 @@
 context('Organizations')
 
 test_that('organizations downloaded', {
-    check_zendesk_login()
+    skip_on_cran()
+    check_api()
     source('testing_login.R')
     all_orgs <- getAllOrganizations()
     expect_is(all_orgs, 'data.frame')

--- a/tests/testthat/test-satisfaction-ratings.R
+++ b/tests/testthat/test-satisfaction-ratings.R
@@ -1,0 +1,9 @@
+context('Satisfaction Ratings')
+
+test_that('satisfaction ratings downloaded', {
+    skip_on_cran()
+    check_api()
+    source('testing_login.R')
+    all_ratings <- getAllSatisfactionRatings()
+    expect_is(all_ratings, 'data.frame')
+})

--- a/tests/testthat/test-ticket-audits.R
+++ b/tests/testthat/test-ticket-audits.R
@@ -1,0 +1,10 @@
+context('Ticket Audits')
+
+test_that('ticket audits downloaded', {
+    skip_on_cran()
+    check_api()
+    source('testing_login.R')
+    ticket_audits <- getTicketAudits(2)
+    expect_is(ticket_audits, 'data.frame')
+    expect_equivalent(nrow(ticket_audits), 1)
+})

--- a/tests/testthat/test-ticket-metrics.R
+++ b/tests/testthat/test-ticket-metrics.R
@@ -1,0 +1,9 @@
+context('Ticket Metrics')
+
+test_that('ticket metrics downloaded', {
+    skip_on_cran()
+    check_api()
+    source('testing_login.R')
+    all_metrics <- getAllTicketMetrics()
+    expect_is(all_metrics, 'data.frame')
+})

--- a/tests/testthat/test-ticket.R
+++ b/tests/testthat/test-ticket.R
@@ -1,0 +1,10 @@
+context('Ticket')
+
+test_that('ticket downloaded', {
+    skip_on_cran()
+    check_api()
+    source('testing_login.R')
+    ticket <- getTicket(2)
+    expect_is(ticket, 'data.frame')
+    expect_equivalent(nrow(ticket), 1)
+})

--- a/tests/testthat/test-tickets.R
+++ b/tests/testthat/test-tickets.R
@@ -1,0 +1,9 @@
+context('Tickets')
+
+test_that('tickets downloaded', {
+    skip_on_cran()
+    check_api()
+    source('testing_login.R')
+    all_tickets <- getAllTickets()
+    expect_is(all_tickets, 'data.frame')
+})

--- a/tests/testthat/test-users.R
+++ b/tests/testthat/test-users.R
@@ -1,0 +1,9 @@
+context('Users')
+
+test_that('users downloaded', {
+    skip_on_cran()
+    check_api()
+    source('testing_login.R')
+    all_users <- getAllUsers()
+    expect_is(all_users, 'data.frame')
+})

--- a/tests/testthat/test-zendesk.R
+++ b/tests/testthat/test-zendesk.R
@@ -1,0 +1,10 @@
+context('Login')
+
+# TODO: Add secure way to test successfull login
+
+test_that('warn users when login unsuccessful', {
+    expect_error(zendesk('fake@email.com','wrong_pw','https://abcfaketest.zendesk.com'))
+    expect_error(zendesk('fake@email.com','wrong_pw'))
+    expect_error(zendesk('fake@email.com', url = 'https://abcfaketest.zendesk.com'))
+    expect_error(zendesk(password = 'wrong_pw', url = 'https://abcfaketest.zendesk.com'))
+})


### PR DESCRIPTION
Adding the testthat framework for all existing functionality. 

The first test in login is aspirational and we might want to decide if we actually want to run a check that the credentials are valid (I can see an argument for not wanting to waste an api call bandwidth on it). I think it would be a nice addition though since it would have saved me time in figuring out I didn't have API access originally. 

getAllTickets and getAllSatisfactionRatings (test-tickets and test-satisfaction-ratings respectively) are admin only so once we add more functionality we can check and skip them if the current user is an admin and skip if not. It would be great if you could run them once and confirm that they pass with an admin account.